### PR TITLE
Fix grammar error in pt-BR app store text

### DIFF
--- a/pt-BR/apple_description_release.lang
+++ b/pt-BR/apple_description_release.lang
@@ -159,12 +159,12 @@ Atualize para o poder do Firefox e<br>Junte-se a milhões de<br>usuários do Fir
 
 # Screenshot description below the title, version 2, adjust line break tag position (<br>) for your language
 ;Upgrade to the power of Firefox and<br>join hundreds of millions of Firefox users
-Atualize para o poder do Firefox e juntar-se<br>a milhões de usuários do Firefox
+Atualize para o poder do Firefox e junte-se<br>a milhões de usuários do Firefox
 
 
 # Screenshot description below the title, version 3, adjust line break tag position (<br>) for your language
 ;Upgrade to Firefox and join<br>hundreds of millions of Firefox users
-Atualize para o Firefox e juntar-se a<br>centenas de milhões de usuários do Firefox
+Atualize para o Firefox e junte-se a<br>centenas de milhões de usuários do Firefox
 
 
 # Adjust line break tag position (<br>) for your language


### PR DESCRIPTION
Looks like version 2 and 3 of the string weren't updated to match version 1.
