### PR TITLE
Add Klar for Android

### DIFF
--- a/de/focus_android/description_release.lang
+++ b/de/focus_android/description_release.lang
@@ -66,3 +66,5 @@ ENTWICKELT VON MOZILLA
 
 ;We believe everyone should have control over their lives online. That’s what we’ve been fighting for since 1998.
 Wir glauben, dass jeder die Kontrolle über sein Online-Leben haben sollte. Dafür kämpfen wir seit 1998.
+
+

--- a/de/focus_android/description_release.lang
+++ b/de/focus_android/description_release.lang
@@ -9,7 +9,7 @@
 # c) Firefox Focus: Private
 # Worst case, you can leave only "Firefox Focus" without punctuation.
 ;Firefox Focus: Private Browser
-Firefox Focus: Privater Browser
+Firefox Focus
 
 
 # Short description. Maximum length is 80 characters.

--- a/de/klar_android/description_release.lang
+++ b/de/klar_android/description_release.lang
@@ -1,15 +1,15 @@
-## NOTE: This is the text used on Play Store for Focus for Android
-## NOTE: See https://l10n.mozilla-community.org/stores_l10n/locale/focus_android/release/
+## NOTE: This is the text used on Play Store for Klar for Android
+## NOTE: See https://l10n.mozilla-community.org/stores_l10n/locale/klar_android/release/
 
 
 # Application title. Maximum length is 30 characters.
 # Given that English is already at the limit, these are possible shorter alternatives:
-# a) Firefox Focus: Private & Fast
-# b) Firefox Focus: Private. Fast
-# c) Firefox Focus: Private
-# Worst case, you can leave only "Firefox Focus" without punctuation.
-;Firefox Focus: Private Browser
-Firefox Focus: Privater Browser
+# a) Firefox Klar: Private & Fast
+# b) Firefox Klar: Private. Fast
+# c) Firefox Klar: Private
+# Worst case, you can leave only "Firefox Klar" without punctuation.
+;Firefox Klar: Private Browser
+Firefox Klar: Privater Browser
 
 
 # Short description. Maximum length is 80 characters.
@@ -24,8 +24,8 @@ Holen Sie sich den privaten Browser. Firefox: Schnell, privat, vertrauenswürdig
 Surfen Sie, als würde niemand zusehen.
 
 
-;The new Firefox Focus automatically blocks a wide range of online trackers — from the moment you launch it to the second you leave it.
-Der neue Firefox Focus blockiert automatisch zahlreiche Elemente zur Aktivitätenverfolgung im Internet – während der ganzen Browsersitzung.
+;The new Firefox Klar automatically blocks a wide range of online trackers — from the moment you launch it to the second you leave it.
+Der neue Firefox Klar blockiert automatisch zahlreiche Elemente zur Aktivitätenverfolgung im Internet – während der ganzen Browsersitzung.
 
 
 ;Easily erase your history, passwords and cookies, so you won’t get followed by things like unwanted ads.
@@ -36,8 +36,8 @@ Löschen Sie einfach Ihre Chronik, Passwörter und Cookies, damit ungewollte Wer
 Der „Private Modus“ in den meisten Browsern ist unvollständig oder schwer einsetzbar.
 
 
-;Focus is next-level privacy that’s free, always on and always on your side — because it’s backed by Mozilla, the non-profit that fights for your rights on the Web.
-Focus bietet eine höhere Form von Datenschutz, die immer verfügbar und immer für Sie da ist – weil Mozilla sie unterstützt, die gemeinnützige Organisation, die sich für Ihre Rechte im Internet einsetzt.
+;Klar is next-level privacy that’s free, always on and always on your side — because it’s backed by Mozilla, the non-profit that fights for your rights on the Web.
+Klar bietet eine höhere Form von Datenschutz, die immer verfügbar und immer für Sie da ist – weil Mozilla sie unterstützt, die gemeinnützige Organisation, die sich für Ihre Rechte im Internet einsetzt.
 
 
 ;AUTOMATIC PRIVACY

--- a/de/klar_android/description_release.lang
+++ b/de/klar_android/description_release.lang
@@ -66,3 +66,5 @@ ENTWICKELT VON MOZILLA
 
 ;We believe everyone should have control over their lives online. That’s what we’ve been fighting for since 1998.
 Wir glauben, dass jeder die Kontrolle über sein Online-Leben haben sollte. Dafür kämpfen wir seit 1998.
+
+

--- a/en-US/klar_android/description_release.lang
+++ b/en-US/klar_android/description_release.lang
@@ -1,0 +1,70 @@
+## NOTE: This is the text used on Play Store for Klar for Android
+## NOTE: See https://l10n.mozilla-community.org/stores_l10n/locale/klar_android/release/
+
+
+## MAX_LENGTH: 30
+# Application title. Maximum length is 30 characters.
+# Given that English is already at the limit, these are possible shorter alternatives:
+# a) Firefox Klar: Private & Fast
+# b) Firefox Klar: Private. Fast
+# c) Firefox Klar: Private
+# Worst case, you can leave only "Firefox Klar" without punctuation.
+;Firefox Klar: Private Browser
+Firefox Klar: Private Browser
+
+
+## MAX_LENGTH: 80
+# Short description. Maximum length is 80 characters.
+# Given that English is already close to the limit, these are possible shorter alternatives:
+# a) Get The Privacy Browser. Fast & always private, from a brand you trust
+# b) Get The Privacy Browser. Fast & always private, from Firefox
+;Get The Privacy Browser. Fast & always private from Firefox, a browser you trust
+Get The Privacy Browser. Fast & always private from Firefox, a browser you trust
+
+
+;Browse like no one’s watching.
+Browse like no one’s watching.
+
+
+;The new Firefox Klar automatically blocks a wide range of online trackers — from the moment you launch it to the second you leave it.
+The new Firefox Klar automatically blocks a wide range of online trackers — from the moment you launch it to the second you leave it.
+
+
+;Easily erase your history, passwords and cookies, so you won’t get followed by things like unwanted ads.
+Easily erase your history, passwords and cookies, so you won’t get followed by things like unwanted ads.
+
+
+;“Private browsing” on most browsers isn’t comprehensive or easy to use.
+“Private browsing” on most browsers isn’t comprehensive or easy to use.
+
+
+;Klar is next-level privacy that’s free, always on and always on your side — because it’s backed by Mozilla, the non-profit that fights for your rights on the Web.
+Klar is next-level privacy that’s free, always on and always on your side — because it’s backed by Mozilla, the non-profit that fights for your rights on the Web.
+
+
+;AUTOMATIC PRIVACY
+AUTOMATIC PRIVACY
+
+
+;Blocks a wide range of common Web trackers without any settings to set
+Blocks a wide range of common Web trackers without any settings to set
+
+
+;Easily erases your history — no passwords, no cookies, no trackers
+Easily erases your history — no passwords, no cookies, no trackers
+
+
+;BROWSE FASTER
+BROWSE FASTER
+
+
+;By removing trackers and ads, Web pages may require less data and load faster
+By removing trackers and ads, Web pages may require less data and load faster
+
+
+;MADE BY MOZILLA
+MADE BY MOZILLA
+
+
+;We believe everyone should have control over their lives online. That’s what we’ve been fighting for since 1998.
+We believe everyone should have control over their lives online. That’s what we’ve been fighting for since 1998.

--- a/fr/klar_android/description_release.lang
+++ b/fr/klar_android/description_release.lang
@@ -1,0 +1,68 @@
+## NOTE: This is the text used on Play Store for Klar for Android
+## NOTE: See https://l10n.mozilla-community.org/stores_l10n/locale/klar_android/release/
+
+
+# Application title. Maximum length is 30 characters.
+# Given that English is already at the limit, these are possible shorter alternatives:
+# a) Firefox Klar: Private & Fast
+# b) Firefox Klar: Private. Fast
+# c) Firefox Klar: Private
+# Worst case, you can leave only "Firefox Klar" without punctuation.
+;Firefox Klar: Private Browser
+Firefox Klar
+
+
+# Short description. Maximum length is 80 characters.
+# Given that English is already close to the limit, these are possible shorter alternatives:
+# a) Get The Privacy Browser. Fast & always private, from a brand you trust
+# b) Get The Privacy Browser. Fast & always private, from Firefox
+;Get The Privacy Browser. Fast & always private from Firefox, a browser you trust
+Le navigateur rapide qui respecte la vie privée, par Firefox.
+
+
+;Browse like no one’s watching.
+Naviguez comme si personne ne vous regardait.
+
+
+;The new Firefox Klar automatically blocks a wide range of online trackers — from the moment you launch it to the second you leave it.
+La nouvelle application Firefox Klar bloque automatiquement une grande variété de traqueurs, de l’instant où vous la lancez jusqu’au moment où vous la quittez.
+
+
+;Easily erase your history, passwords and cookies, so you won’t get followed by things like unwanted ads.
+Effacez facilement votre historique, vos mots de passe et vos cookies, afin de vous libérer de certains éléments comme les publicités indésirables.
+
+
+;“Private browsing” on most browsers isn’t comprehensive or easy to use.
+La « Navigation privée » de la plupart des navigateurs est incomplète et difficile à utiliser.
+
+
+;Klar is next-level privacy that’s free, always on and always on your side — because it’s backed by Mozilla, the non-profit that fights for your rights on the Web.
+Klar fait passer la vie privée à un tout autre niveau. Parce qu’il est réalisé par Mozilla, l’organisation à but non lucratif qui défend vos droits sur le Web, il est gratuit, reste activé en permanence et se trouve toujours de votre côté.
+
+
+;AUTOMATIC PRIVACY
+LA CONFIDENTIALITÉ PAR DÉFAUT
+
+
+;Blocks a wide range of common Web trackers without any settings to set
+Bloquez une grande variété de traqueurs web répandus sans avoir à configurer quoi que ce soit
+
+
+;Easily erases your history — no passwords, no cookies, no trackers
+Effacez facilement votre historique : pas de mots de passe, pas de cookies, pas de traqueurs
+
+
+;BROWSE FASTER
+NAVIGUEZ PLUS RAPIDEMENT
+
+
+;By removing trackers and ads, Web pages may require less data and load faster
+En supprimant les publicités, les pages web nécessitent moins de données et se chargent plus vite
+
+
+;MADE BY MOZILLA
+RÉALISÉ PAR MOZILLA
+
+
+;We believe everyone should have control over their lives online. That’s what we’ve been fighting for since 1998.
+Nous pensons que chacun devrait être aux commandes de sa vie en ligne. C’est ce pour quoi nous nous battons depuis 1998.

--- a/fr/klar_android/description_release.lang
+++ b/fr/klar_android/description_release.lang
@@ -66,3 +66,5 @@ RÉALISÉ PAR MOZILLA
 
 ;We believe everyone should have control over their lives online. That’s what we’ve been fighting for since 1998.
 Nous pensons que chacun devrait être aux commandes de sa vie en ligne. C’est ce pour quoi nous nous battons depuis 1998.
+
+

--- a/it/klar_android/description_release.lang
+++ b/it/klar_android/description_release.lang
@@ -1,0 +1,68 @@
+## NOTE: This is the text used on Play Store for Klar for Android
+## NOTE: See https://l10n.mozilla-community.org/stores_l10n/locale/klar_android/release/
+
+
+# Application title. Maximum length is 30 characters.
+# Given that English is already at the limit, these are possible shorter alternatives:
+# a) Firefox Klar: Private & Fast
+# b) Firefox Klar: Private. Fast
+# c) Firefox Klar: Private
+# Worst case, you can leave only "Firefox Klar" without punctuation.
+;Firefox Klar: Private Browser
+Firefox Klar, browser privato
+
+
+# Short description. Maximum length is 80 characters.
+# Given that English is already close to the limit, these are possible shorter alternatives:
+# a) Get The Privacy Browser. Fast & always private, from a brand you trust
+# b) Get The Privacy Browser. Fast & always private, from Firefox
+;Get The Privacy Browser. Fast & always private from Firefox, a browser you trust
+Il browser veloce e attento alla privacy. Da Firefox, un browser di cui fidarsi.
+
+
+;Browse like no one’s watching.
+Naviga come se nessuno ti stesse guardando.
+
+
+;The new Firefox Klar automatically blocks a wide range of online trackers — from the moment you launch it to the second you leave it.
+Il nuovo Firefox Klar blocca automaticamente gli elementi traccianti più diffusi durante la navigazione, dall’istante in cui lo apri a quando lo chiudi.
+
+
+;Easily erase your history, passwords and cookies, so you won’t get followed by things like unwanted ads.
+Cancella con facilità cronologia, password e cookie, liberandoti finalmente da elementi traccianti noiosi come gli annunci pubblicitari indesiderati.
+
+
+;“Private browsing” on most browsers isn’t comprehensive or easy to use.
+La cosiddetta “navigazione anonima” dei comuni browser è incompleta e difficile da utilizzare.
+
+
+;Klar is next-level privacy that’s free, always on and always on your side — because it’s backed by Mozilla, the non-profit that fights for your rights on the Web.
+Klar porta la privacy a un nuovo livello: gratuito, sempre attivo e sempre dalla tua parte, perché è sviluppato da Mozilla, l'organizzazione senza fini di lucro che salvaguarda i diritti degli utenti sul Web.
+
+
+;AUTOMATIC PRIVACY
+PRIVACY IN AUTOMATICO
+
+
+;Blocks a wide range of common Web trackers without any settings to set
+Blocca gli elementi traccianti più diffusi sul Web senza bisogno di impostare alcun parametro
+
+
+;Easily erases your history — no passwords, no cookies, no trackers
+Elimina facilmente la cronologia: niente password, niente cookie, niente elementi traccianti
+
+
+;BROWSE FASTER
+NAVIGAZIONE PIÙ VELOCE
+
+
+;By removing trackers and ads, Web pages may require less data and load faster
+Senza elementi traccianti e annunci pubblicitari ad appesantirle, le pagine web si caricano più velocemente
+
+
+;MADE BY MOZILLA
+SVILUPPATO DA MOZILLA
+
+
+;We believe everyone should have control over their lives online. That’s what we’ve been fighting for since 1998.
+Ogni utente dovrebbe avere il pieno controllo della propria esperienza online e Mozilla si batte per questo diritto dal 1998.

--- a/it/klar_android/description_release.lang
+++ b/it/klar_android/description_release.lang
@@ -66,3 +66,5 @@ SVILUPPATO DA MOZILLA
 
 ;We believe everyone should have control over their lives online. That’s what we’ve been fighting for since 1998.
 Ogni utente dovrebbe avere il pieno controllo della propria esperienza online e Mozilla si batte per questo diritto dal 1998.
+
+


### PR DESCRIPTION
CC @Delphine, @TheoChevalier @koehlermichael @Archaeopteryx 

Heads up. Since Google Play content is updated automatically (unlike iOS), we have a problem with the Klar/Focus branding.

Focus and Klar are two different applications, targeting different regions. Right now German had "Klar" in the Focus for Android description, meaning that a user with Android in German located in US would download "Focus for Android", with a description talking about Klar.

This PR adds "translations" for Klar in German, Italian, French:
* For Italian and French I copied over the existing translations, and replaced Focus with Klar in the text.
* For German I replaced Klar with Focus in the focus description, and copied over the existing translation for Klar. I had to shorten the title, because `Firefox Focus: Privater Browser` is too long (31 vs 30 characters limit).

There's no need to do anything on your side, it's mostly an FYI. Unfortunately, if you need to update a string in these descriptions, you will have to do it for both products.